### PR TITLE
fix tabu reset and max slope update

### DIFF
--- a/src/main/scala/combinator/BanditSelector.scala
+++ b/src/main/scala/combinator/BanditSelector.scala
@@ -161,7 +161,7 @@ abstract class BanditSelector(
     appendStats(stats, neighborhood)
     searchResult match {
       case NoMoveFound  => setTabu(neighborhood)
-      case MoveFound(_) =>
+      case MoveFound(_) => resetTabu()
     }
     learningScheme match {
       case AfterEveryMove =>
@@ -189,7 +189,7 @@ abstract class BanditSelector(
     neighborhoodStats: NeighborhoodStats,
     neighborhood: Neighborhood
   ): Unit = {
-    maxSlope = Math.max(maxSlope, neighborhoodStats.slope)
+    maxSlope = Math.max(maxSlope, Math.abs(neighborhoodStats.slope))
     maxRunTimeNano = Math.max(maxRunTimeNano, neighborhoodStats.timeNano)
     val idx = neighborhoodIdx(neighborhood)
     stats(idx).append(neighborhoodStats)


### PR DESCRIPTION
The following bugs were found inside the `BanditSelector`
- The reset of the tabu list (i.e. neighborhood marked as invalid because they did not found a move) was not called once a new move has been found.
- The update of the maximum ever observed did not use a Math.abs() instruction 